### PR TITLE
Added how to run on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,41 @@
-# demo
+# EOEPCA Demo Notebooks
 
-Demonstration of Common Architecture building blocks.
+Collection of Jupyter notebooks to demonstrate of Common Architecture building blocks functionalities.
 
-Uses docker-compose to run the demo in a local JupyterLab instance.
+## Notebooks
 
-## notebooks
+The notebooks are under directory [demoroot/notebooks](demoroot/notebooks), with supporting files under [demoroot/data](demoroot/data).
 
-The notebooks are under directory 'demoroot/notebooks', with supporting files under 'demoroot/data'.
+## Execution
 
-## build
+To run the notebooks, you will need a Jupyter Notebook instance.
 
-The docker image is built with `docker-compose`:
+You can start one on your PC or a remote server, follow the instructions below.
+
+### Windows
+
+Download [WinPython (dot version)](https://winpython.github.io/) and extract it in a folder on your PC.
+
+Download [this repository](https://github.com/EOEPCA/demo/archive/refs/heads/main.zip) and extract it in the `notebooks` sub-folder of your `WPy64` installation.
+
+Run the `WinPython Command Prompt.exe` software in the `WPy64` folder and run the following command to install the EOEPCA demo notebook pre-requisites:
+
+```console
+python.exe -m pip install --upgrade pip
+pip install -r ../notebooks/demo-main/demoroot/requirements.txt
+```
+
+Exit the `WinPython Command Prompt.exe` application and run the `Jupyter Notebook.exe` application
+
+Open one of the notebooks in the `notebooks/demo-main/demoroot/notebooks` directory and run it.
+
+### Linux
+
+You can use Docker to run a local JupyterLab instance.
+
+To do so, first install docker and docker-compose, following the [official instructions](https://docs.docker.com/engine/install/)
+
+Then you can build the docker image with `docker-compose`:
 
 ```console
 docker-compose build
@@ -18,17 +43,15 @@ docker-compose build
 
 The built container bundles the notebooks and supporting files.
 
-## run
+To run the application you can then run
 
 ```console
 docker-compose up
 ```
 
-Open your browser at [http://0.0.0.0:8888](http://0.0.0.0:8888)
+And open your browser at [http://0.0.0.0:8888](http://0.0.0.0:8888)
 
-## develop
-
-Use the commandline arg to mount the local notebook files into the running container for local development...
+NOTE: To keep changes to the notebooks after the closure of the docker container, so for example for local devlopment, you can use the following command line to mount the local notebook files into the running container, via
 
 ```console
 docker-compose -f docker-compose-dev.yml up

--- a/demoroot/requirements.txt
+++ b/demoroot/requirements.txt
@@ -1,4 +1,5 @@
 identityutils @ git+https://github.com/eoepca/um-identity-service@v1.0.10
+notebook
 awscli==1.29.68
 boto3==1.28.68
 bs4==0.0.1
@@ -11,7 +12,6 @@ lxml==5.2.2
 matplotlib==3.8.0
 OWSLib==0.29.2
 PyYAML==5.3.1
-pycrypto==2.6.1
 pyjwkest==1.4.2
 pystac-client==0.6.1
 rauth==0.7.3


### PR DESCRIPTION
Hi,
I have rewritten the README to add info on how to run on Windows (as not everyone may have a Linux server on their hands when testing stuff). I have also removed `pycrypto` from the requirements (which I think is not used, and does not compile on Windows) and I have added the `notebook` package in the requirement (so even if you are not starting from the Docker notebook base image you will get it installed)